### PR TITLE
Update pydpkg dependency to handle xz-compressed control files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 *.whl
 wheelhouse/
 .ropeproject/
+venv*
+MANIFEST
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
 before_install:
   - "pip install -U pip"
 install:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+include LICENSE.txt
+include README.md
+include setup.*
+graft apt_repoman

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,25 @@
+#!/bin/sh -ex
+
+if ! [ -f venv/bin/activate ]; then
+  virtualenv --python=$(which python3) venv
+fi
+
+. venv/bin/activate
+
+pip install -U pip setuptools twine
+
+python setup.py sdist bdist_wheel
+
+deactivate
+
+if ! [ -f venv2/bin/activate ]; then
+  virtualenv --python=$(which python2) venv2
+fi
+
+. venv2/bin/activate
+
+pip install -U pip setuptools
+
+python setup.py bdist_wheel
+
+venv/bin/twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,15 @@
 from setuptools import setup, find_packages
 
 __name__ = 'apt-repoman'
-__version__ = '1.0.4'
+__version__ = '1.0.5'
 
 setup(
     name=__name__,
     packages=find_packages(),
     version=__version__,
     description='A high performance Debian APT repository based on Amazon Web Services',
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
     author='Nathan J. Mehl',
     author_email='n@climate.com',
     url='https://github.com/theclimatecorporation/repoman',
@@ -17,20 +19,17 @@ setup(
     keywords=['apt', 'debian', 'dpkg', 'packaging'],
     package_data={'': ['*.json']},
     install_requires=[
-        'PGPy==0.4.1',
+        'PGPy==0.5.2',
         'ansicolors==1.1.8',
         'boto3==1.4.4',
         'configargparse==0.12.0',
-        'pydpkg==1.3.1',
+        'pydpkg==1.3.2',
         'pysectools==0.4.2',
         'tabulate==0.7.7'
     ],
     extras_require={
         'test': ['mock==2.0.0', 'pep8==1.7.0', 'pytest==3.1.1', 'pylint==1.7.1']
     },
-    #scripts=[
-    #    'scripts/repoman'
-    #],
     entry_points = {
         'console_scripts': ['repoman-cli=apt_repoman.cli:main'],
     },
@@ -38,9 +37,10 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: System :: Archiving :: Packaging",
         ]


### PR DESCRIPTION
- Update pydpkg dependency to handle xz-compressed control files

- Update PGPy dependency to 0.5.2 to resolve build errors. (cf: https://github.com/SecurityInnovation/PGPy/issues/217)

- Deprecate Python 3.3 support

- Add support for python 3.6, 3.7

- fix setup.py long description handling

- Bump version to 1.0.5